### PR TITLE
[FIX] Remove json dependancy

### DIFF
--- a/iron_worker.gemspec
+++ b/iron_worker.gemspec
@@ -18,6 +18,5 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = Gem::Requirement.new(">= 1.9")
   gem.add_runtime_dependency "iron_core", ">= 1.0.12", '< 2'
   gem.add_runtime_dependency 'rest', '~> 3.0', ">= 3.0.8"
-  gem.add_runtime_dependency "json", "~> 1.8", "> 1.8.1"
 
 end


### PR DESCRIPTION
## Description
iron_worker is not compatible with ruby2.5 and so is not usable in our `migrate` worker

## Test
https://github.com/dakis/minions/pull/200